### PR TITLE
Bug fixing for AWS and Server Core

### DIFF
--- a/.github/workflows/devel_pipeline_validation.yml
+++ b/.github/workflows/devel_pipeline_validation.yml
@@ -49,6 +49,9 @@ jobs:
             ARM_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
             WIN_USERNAME: ${{ secrets.WIN_USERNAME }}
             WIN_PASSWORD: ${{ secrets.WIN_PASSWORD }}
+            OSVAR: ${{ vars.OSVAR }}
+            TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
+            TF_VAR_run_job_id: ${{ github.run_id }}
 
         defaults:
             run:
@@ -83,38 +86,20 @@ jobs:
                 echo "benchmark_type = $benchmark_type"
                 pwd
                 ls
-              env:
-                  # Imported from github variables this is used to load the relvent OS.tfvars file
-                  OSVAR: ${{ vars.OSVAR }}
-                  TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
           # Initialize The Terraform Working Directory
             - name: Terraform_Init
               id: init
               run: terraform init
-              env:
-                # Imported from github variables this is used to load the relvent OS.tfvars file
-                  OSVAR: ${{ vars.OSVAR }}
-                  TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
           # Validate The Syntax Of Terraform Files
             - name: Terraform_Validate
               id: validate
               run: terraform validate
-              env:
-                # Imported from github variables this is used to load the relvent OS.tfvars file
-                  OSVAR: ${{ vars.OSVAR }}
-                  TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
 
           # Execute The Actions And Build Azure Server
             - name: Terraform_Apply
               id: apply
-              env:
-                # Imported from github variables this is used to load the relvent OS.tfvars file
-                  WIN_USERNAME: ${{ secrets.WIN_USERNAME }}
-                  WIN_PASSWORD: ${{ secrets.WIN_PASSWORD }}
-                  OSVAR: ${{ vars.OSVAR }}
-                  TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
               run: terraform apply -var-file "${OSVAR}.tfvars" --auto-approve
 
           # Debug Section
@@ -137,7 +122,4 @@ jobs:
           # Destroy The Azure Test System
             - name: Terraform_Destroy
               if: always() && env.ENABLE_DEBUG == 'false'
-              env:
-                  OSVAR: ${{ vars.OSVAR }}
-                  TF_VAR_benchmark_type: ${{ vars.BENCHMARK_TYPE }}
               run: terraform destroy -var-file "${OSVAR}.tfvars" --auto-approve

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ win22stig_lengthy_search: false
 # different environments. By Default This is set to false.
 win22stig_cloud_based_system: false
 
+# This will be changed to true if discovered for server core type.
+wni22stig_system_is_core: false
+
 # win_skip_for_test is used in the playbook to skip over WINRM based controls that
 # may cause WINRM Basic Connection Type to be disabled.
 # Setting win_skip_for_test to 'false' will enable Secure Connection types only.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ win22stig_lengthy_search: false
 win22stig_cloud_based_system: false
 
 # This will be changed to true if discovered for server core type.
-wni22stig_system_is_core: false
+win22stig_is_server_core: false
 
 # win_skip_for_test is used in the playbook to skip over WINRM based controls that
 # may cause WINRM Basic Connection Type to be disabled.

--- a/tasks/cat1.yml
+++ b/tasks/cat1.yml
@@ -548,10 +548,10 @@
       - V-254492
 
 - name: "HIGH | WN22-UR-000060 | PATCH | Windows Server 2022 Create a token object user right must not be assigned to any groups or accounts."
-  community.windows.win_security_policy:
-      section: Privilege Rights
-      key: SeCreateTokenPrivilege
-      value: ""
+  ansible.windows.win_user_right:
+      name: SeCreateTokenPrivilege
+      users: []
+      action: set
   when:
       - wn22_ur_000060
   tags:

--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -998,6 +998,7 @@
   notify: reboot_windows
   when:
       - wn22_00_000320
+      - not win22stig_is_server_core
   tags:
       - WN22-00-000320
       - CAT2
@@ -1070,6 +1071,7 @@
       state: absent
   when:
       - wn22_00_000370
+      - not win22stig_is_server_core
   tags:
       - WN22-00-000370
       - CAT2

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -16,6 +16,7 @@
   ansible.builtin.set_fact:
       win22stig_cloud_based_system: true
   when:
+      - ansible_system_vendor == 'Microsoft Corporation'
       - ansible_virtualization_type == 'Hyper-V' or
         ansible_virtualization_type == 'hvm' or
         ansible_virtualization_type == 'kvm'
@@ -60,3 +61,10 @@
   when:
       - wn22_00_000390 or
         wn22_00_000400
+
+- name: Set Fact If Server Core installation
+  ansible.builtin.set_fact:
+      win22stig_is_server_core: true
+  when: ansible_os_installation_type == 'Server Core'
+  tags:
+      - always


### PR DESCRIPTION
**Overall Review of Changes:**
Cloud Detection only applies to Azure as AWS images fails to build with the alternate cat2 ordering.

**Issue Fixes:**
[Windows 2019 STIG #57](https://github.com/ansible-lockdown/Windows-2019-STIG/issues/57)
[Windows 2019 STIG #58](https://github.com/ansible-lockdown/Windows-2019-STIG/issues/58)

**Enhancements:**
None

**How has this been tested?:**
N/A
