### PR TITLE
Fix WN22-SO-000370: set ProtectionMode registry datatype to dword

### DIFF
--- a/tasks/cat3.yml
+++ b/tasks/cat3.yml
@@ -250,7 +250,7 @@
       path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager
       value: ProtectionMode
       data: 1
-      datatype: string
+      datatype: dword
   when:
       - wn22_so_000370
   tags:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fix LOW | WN22-SO-000370 | PATCH | Windows Server 2022 default permissions of global system objects must be strengthened.

The ProtectionMode registry value under HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager was being written with datatype: string instead of datatype: dword, causing the SCAP audit to fail.

**Issue Fixes:**
Closes #12 

**Enhancements:**
N/A

**How has this been tested?:**
Tested against Windows Server 2022 using the Microsoft Windows Server 2022 STIG SCAP Benchmark. After applying the fix, the corresponding rule passes audit.

