### PR TITLE
Fix WN22-AU-000090: enable success auditing for Other Account Management Events

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -2052,8 +2052,8 @@
         register: wn22_au_000090_audit
 
       - name: "MEDIUM | WN22-AU-000090 | PATCH | Windows Server 2022 must be configured to audit Account Management | Other Account Management Events successes."
-        ansible.windows.win_shell: AuditPol /set /subcategory:"Other Account Management Events" /failure:enable
-        when: "'Failure' not in wn22_au_000090_audit.stdout"
+        ansible.windows.win_shell: AuditPol /set /subcategory:"Other Account Management Events" /success:enable
+        when: "'Success' not in wn22_au_000090_audit.stdout"
   when:
       - wn22_au_000090
   tags:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fix MEDIUM | WN22-AU-000090 | PATCH | Windows Server 2022 must be configured to audit Account Management | Other Account Management Events successes.
                                                                                                                                                                                                            
The AuditPol command was using /failure:enable instead of /success:enable, and the when condition was checking for 'Failure' instead of 'Success', causing success auditing to never be applied.

**Issue Fixes:**
Closes #14 

**Enhancements:**
N/A

**How has this been tested?:**
Tested against Windows Server 2022 using the Microsoft Windows Server 2022 STIG SCAP Benchmark. After applying the fix, corresponding rule passes audit.
