### PR TITLE
Fix WN22-AU-000330: correct when condition to check for failure auditing

### DIFF
--- a/tasks/cat2.yml
+++ b/tasks/cat2.yml
@@ -2665,7 +2665,7 @@
 
       - name: "MEDIUM | WN22-AU-000330 | PATCH | Windows Server 2022 must be configured to audit System | IPsec Driver failures."
         ansible.windows.win_shell: AuditPol /set /subcategory:"IPsec Driver" /failure:enable
-        when: "'Success' not in wn22_au_000330_audit.stdout"
+        when: "'Failure' not in wn22_au_000330_audit.stdout"
   when:
       - wn22_au_000330
   tags:


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fix MEDIUM | WN22-AU-000330 | PATCH | Windows Server 2022 must be configured to audit System | IPsec Driver failures.                                                                                     
                                                                                                                                                                                                            
The when condition was checking for 'Success' not in the audit output, but the task configures /failure:enable. This caused failure auditing to be skipped incorrectly. The condition should check for 'Failure' not in to match the audit type being configured.

**Issue Fixes:**
Closes #16 

**Enhancements:**
N/A

**How has this been tested?:**
Tested against Windows Server 2022 using the Microsoft Windows Server 2022 STIG SCAP Benchmark. After applying the fix, the corresponding rule passes audit.